### PR TITLE
Bug/ps 172 undefinedfunctionerror function ypsilonweb y pagecontroller dummy 2 is undefined or private

### DIFF
--- a/lib/set_locale.ex
+++ b/lib/set_locale.ex
@@ -27,17 +27,17 @@ defmodule SetLocale do
 
   def call(
         %{
+          request_path: request_path,
           params: %{
             "locale" => requested_locale
           }
         } = conn,
         config
       ) do
-    if supported_locale?(requested_locale, config) do
+    if request_path != "/" and supported_locale?(requested_locale, config) do
       if Enum.member?(config.additional_locales, requested_locale),
         do: Gettext.put_locale(config.gettext, config.default_locale),
         else: Gettext.put_locale(config.gettext, requested_locale)
-
       assign(conn, :locale, requested_locale)
     else
       path = rewrite_path(conn, requested_locale, config)

--- a/test/set_locale_test.exs
+++ b/test/set_locale_test.exs
@@ -326,6 +326,15 @@ defmodule SetLocaleTest do
   end
 
   describe "when an existing locale is given" do
+    test "when a root path is requested, it should redirect to the requested locale" do
+      assert Gettext.get_locale(MyGettext) == "en"
+      conn = Phoenix.ConnTest.build_conn(:get, "/", %{"locale" => "nl"})
+             |> Plug.Conn.fetch_cookies()
+             |> SetLocale.call(@default_options)
+
+      assert redirected_to(conn) == "/nl"
+    end
+
     test "with sibling: it should only assign it" do
       conn =
         Phoenix.ConnTest.build_conn(:get, "/en-gb/foo/bar/baz", %{"locale" => "en-gb"})


### PR DESCRIPTION
I created two branches with the same changes:
 - this branch, `bug/ps-172-undefinedfunctionerror-function-ypsilonweb-y-pagecontroller-dummy-2-is-undefined-or-private`, forked from our master which includes changes for additional locales that we need for the bablic/french stuff. Not sure why it's already in master here while it wasn't merged to main app.
- branch `bug/root-path-locale-query-param` which was forked from smeevil master, and has an open PR there: https://github.com/smeevil/set_locale/pull/19

I am aware that the changes from our master also have an open PR https://github.com/smeevil/set_locale/pull/18, that's why I did two separate branches, and I guess either Dirk or I will have to resolve conflicts when the other person's PR gets merged first.